### PR TITLE
Release 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.3.5] - 2026-05-01
+
+### Changed
+- **Multi-line formatting for wide records and signatures**: Record types with more than 3 keys and method signatures with more than 3 parameters are now emitted across multiple lines in `.rbs` output. Previously these collapsed onto a single line, producing 1500+ character lines that were unreadable in PR diffs. Records and signatures with 3 or fewer entries are unaffected. (#10)
+
+  Before:
+  ```rbs
+  type applicant_local = { external_id: String, name: String, email: String, status: String }
+  ```
+  After:
+  ```rbs
+  type applicant_local = {
+    external_id: String,
+    name: String,
+    email: String,
+    status: String,
+  }
+  ```
+
+### Migration notes
+- Regenerating signatures will produce a one-time diff in committed `sig/` files for any record or method over the 3-entry threshold. The output is semantically identical — re-run `sentinel init` to land the formatting change in one commit.
+
 ## [0.3.4] - 2026-03-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sentinel-rb"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentinel-rb"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 authors = ["Andy Gauger <https://github.com/andygauge>"]
 description = "High-speed Rust sidecar for Ruby Type-Safety and Agentic Orchestration"

--- a/sentinel-gem/rbs-sentinel.gemspec
+++ b/sentinel-gem/rbs-sentinel.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "rbs-sentinel"
-  spec.version       = "0.3.4"
+  spec.version       = "0.3.5"
   spec.executables   = ["sentinel"]
   spec.bindir        = "bin"
   spec.authors       = ["Andrew Gauger"]


### PR DESCRIPTION
## Summary
- Bumps `rbs-sentinel` to 0.3.5 (and `sentinel-rb` crate to match).
- Folds in #10 — wide record types and long method signatures now wrap onto multiple lines in compiled `.rbs` output instead of collapsing onto one 1500+ character line.

## Changelog
See `CHANGELOG.md`. Highlights:
- **Changed:** Records with >3 keys and signatures with >3 params emit on multiple lines. ≤3 entries unaffected.
- **Migration notes:** Regenerating signatures will produce a one-time formatting diff in committed `sig/` files for any record/sig over the threshold. Output is semantically identical — `sentinel init` lands the change in one commit.

## Follow-ups after merge
- Run `scripts/release.sh` from `master` to cross-compile the four platform binaries (aarch64/x86_64 × darwin/linux) and rebuild `rbs-sentinel-0.3.5.gem` with the fresh binaries — the smoke-built gem on this branch still bundles the 0.3.4 binaries.
- Tag `v0.3.5` on the merge commit and push the tag (note: latest tag in repo is `v0.2.1` — tags have drifted behind releases; this would be a good time to backfill or just resume tagging from here).
- `gem push sentinel-gem/rbs-sentinel-0.3.5.gem` to rubygems.org.
- Consider a separate PR adding `CHANGELOG.md` to `spec.files` in `rbs-sentinel.gemspec` so consumers see the changelog via `bundle show rbs-sentinel`. The CHANGELOG lives at the repo root, not under `sentinel-gem/`, so this needs a small structural decision (copy/symlink/glob-up) — out of scope for the release itself.

## Test plan
- [x] `cargo test` — 43 passed, 0 failed
- [x] `gem build rbs-sentinel.gemspec` produces `rbs-sentinel-0.3.5.gem`

🤖 Generated with [Claude Code](https://claude.com/claude-code)