### PR TITLE
Strip MCP annotations from `# @rbs type` aliases

### DIFF
--- a/src/transpiler.rs
+++ b/src/transpiler.rs
@@ -216,6 +216,7 @@ impl SentinelTranspiler {
                 if !continues {
                     let alias = pending_type_alias.take().unwrap();
                     if Self::is_balanced(&alias) && !alias.ends_with('|') {
+                        let alias = Self::strip_annotations(&alias);
                         info.type_aliases.push(format!("type {}", alias));
                     }
                 }
@@ -340,6 +341,7 @@ impl SentinelTranspiler {
         // Finalize any remaining pending type alias
         if let Some(alias) = pending_type_alias {
             if Self::is_balanced(&alias) && !alias.ends_with('|') {
+                let alias = Self::strip_annotations(&alias);
                 info.type_aliases.push(format!("type {}", alias));
             }
         }
@@ -1631,6 +1633,80 @@ end
         assert!(
             result.contains("attr_reader name: String"),
             "Expected clean attr_reader, got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_strip_annotations_on_type_alias_record() {
+        // Regression: 0.3.6 stripped @desc/@example/etc. from method signatures
+        // but left them inside `# @rbs type` aliases, where Steep also rejects
+        // them with `RBS::SyntaxError: cannot start a declaration, token=@desc`
+        // when they appear inside a record-type's `{ ... }`.
+        let test_file = Path::new("/tmp/test_strip_type_alias_record.rb");
+        fs::write(
+            test_file,
+            "\
+class Applicant
+  # @rbs type applicant_local = {
+  #   external_id: String @desc(Stable applicant external_id) @example(app_123) @read_only(),
+  #   email: String @format(email) @desc(Primary email) @example(jane@example.com),
+  # }
+end
+",
+        )
+        .unwrap();
+
+        let mut transpiler = SentinelTranspiler::new();
+        let result = transpiler.transpile_file(test_file).unwrap();
+        for tag in ["@desc", "@example", "@read_only", "@format"] {
+            assert!(
+                !result.contains(tag),
+                "Expected {} to be stripped from type alias, got: {}",
+                tag,
+                result
+            );
+        }
+        assert!(
+            result.contains("external_id: String"),
+            "Expected external_id field preserved, got: {}",
+            result
+        );
+        assert!(
+            result.contains("email: String"),
+            "Expected email field preserved, got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_strip_annotations_on_single_line_type_alias() {
+        let test_file = Path::new("/tmp/test_strip_type_alias_single.rb");
+        fs::write(
+            test_file,
+            "\
+class Funnel
+  # @rbs type funnel_ref = { external_id: String @desc(Opening external_id) @example(funnel_abc), title: String @desc(Title shown in UI) }
+end
+",
+        )
+        .unwrap();
+
+        let mut transpiler = SentinelTranspiler::new();
+        let result = transpiler.transpile_file(test_file).unwrap();
+        assert!(
+            !result.contains("@desc"),
+            "Expected @desc to be stripped from single-line alias, got: {}",
+            result
+        );
+        assert!(
+            !result.contains("@example"),
+            "Expected @example to be stripped from single-line alias, got: {}",
+            result
+        );
+        assert!(
+            result.contains("type funnel_ref"),
+            "Expected type alias preserved, got: {}",
             result
         );
     }


### PR DESCRIPTION
## Summary

0.3.6 stripped MCP-style tags (`@desc(...)`, `@example(...)`, `@min(...)`, `@format(...)`, etc.) from `#:` method signatures, but `# @rbs type` aliases were still pushed into the generated `.rbs` verbatim. Steep rejects those tags inside record-type braces with the same `RBS::SyntaxError: cannot start a declaration, token=@desc` error, which forced downstream consumers to keep their per-file `ignore_signature` workarounds even after upgrading.

This calls `strip_annotations` on the alias body before pushing it into `info.type_aliases`, mirroring the method-signature path. Both code paths that finalize an alias are covered (the mid-walk `if !continues` branch and the end-of-file finalizer).

## Why

The 0.3.6 release notes promised the strip feature, but it only fired on `#:` signatures. The Hire monolith bumped to 0.3.6 and tried to remove its 5 `ignore_signature` Steepfile entries — Steep then rejected the type-alias `@desc` tags, so the workaround had to stay. This closes that gap.

## Test plan

- [x] `cargo test` — 51 passed, 0 failed (added 2 new tests for type-alias stripping: one multi-line record, one single-line)
- [ ] After merge: rebuild binaries, bump to 0.3.7, publish gem
- [ ] Verify in monolith: removing `ignore_signature` lines from `Steepfile` and the matching `sig/hand/services/tool/` stubs leaves Steep clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)