### PR TITLE
Add `# @rbs import` directive for shared type definitions

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -8,7 +8,7 @@ use std::sync::Mutex;
 use std::time::Instant;
 use walkdir::WalkDir;
 
-pub fn run(app_path: &Path, output_path: &Path) -> bool {
+pub fn run(app_path: &Path, output_path: &Path, shared_paths: &[PathBuf]) -> bool {
     let start = Instant::now();
     let app_root = app_path
         .canonicalize()
@@ -45,6 +45,7 @@ pub fn run(app_path: &Path, output_path: &Path) -> bool {
 
     files.par_iter().for_each(|path| {
         let mut transpiler = SentinelTranspiler::new();
+        transpiler.set_shared_paths(shared_paths.to_vec());
 
         match transpiler.transpile_file(path) {
             Ok(rbs_content) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,12 @@ const CONFIG_FILE: &str = ".sentinel.toml";
 pub struct SentinelConfig {
     pub folders: Vec<String>,
     pub output: String,
+    #[serde(default = "default_shared_paths")]
+    pub shared_paths: Vec<String>,
+}
+
+fn default_shared_paths() -> Vec<String> {
+    vec!["sig/shared".to_string()]
 }
 
 impl Default for SentinelConfig {
@@ -15,6 +21,7 @@ impl Default for SentinelConfig {
         Self {
             folders: vec!["app".to_string()],
             output: "sig/generated".to_string(),
+            shared_paths: default_shared_paths(),
         }
     }
 }
@@ -80,5 +87,10 @@ impl SentinelConfig {
     /// Return folder paths.
     pub fn folder_paths(&self) -> Vec<PathBuf> {
         self.folders.iter().map(PathBuf::from).collect()
+    }
+
+    /// Return shared type paths.
+    pub fn shared_type_paths(&self) -> Vec<PathBuf> {
+        self.shared_paths.iter().map(PathBuf::from).collect()
     }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 use walkdir::WalkDir;
 
-pub fn run(app_path: &Path, output_path: &Path) {
+pub fn run(app_path: &Path, output_path: &Path, shared_paths: &[PathBuf]) {
     let start = Instant::now();
     let app_root = app_path
         .canonicalize()
@@ -41,6 +41,7 @@ pub fn run(app_path: &Path, output_path: &Path) {
 
     files.par_iter().for_each(|path| {
         let mut transpiler = SentinelTranspiler::new();
+        transpiler.set_shared_paths(shared_paths.to_vec());
 
         match transpiler.transpile_file(path) {
             Ok(rbs_content) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,15 +18,17 @@ async fn main() -> Result<()> {
         "init" => {
             let config = SentinelConfig::ensure_exists()?;
             std::fs::create_dir_all(config.output_path())?;
+            let shared = config.shared_type_paths();
             for folder in config.folder_paths() {
-                init::run(&folder, &config.output_path());
+                init::run(&folder, &config.output_path(), &shared);
             }
         }
         "check" => {
             let config = SentinelConfig::load()?;
+            let shared = config.shared_type_paths();
             let mut all_ok = true;
             for folder in config.folder_paths() {
-                if !check::run(&folder, &config.output_path()) {
+                if !check::run(&folder, &config.output_path(), &shared) {
                     all_ok = false;
                 }
             }
@@ -37,8 +39,9 @@ async fn main() -> Result<()> {
         "watch" => {
             let config = SentinelConfig::ensure_exists()?;
             std::fs::create_dir_all(config.output_path())?;
+            let shared = config.shared_type_paths();
             for folder in config.folder_paths() {
-                init::run(&folder, &config.output_path());
+                init::run(&folder, &config.output_path(), &shared);
             }
             let watcher = SentinelWatcher::new(&config)?.with_plugins();
             watcher.run().await;

--- a/src/transpiler.rs
+++ b/src/transpiler.rs
@@ -18,6 +18,7 @@ struct ClassInfo {
 
 pub struct SentinelTranspiler {
     parser: Parser,
+    shared_paths: Vec<std::path::PathBuf>,
 }
 
 impl SentinelTranspiler {
@@ -28,7 +29,67 @@ impl SentinelTranspiler {
             .set_language(lang)
             .expect("Error loading Ruby grammar");
 
-        Self { parser }
+        Self {
+            parser,
+            shared_paths: Vec::new(),
+        }
+    }
+
+    /// Set the directories to search for shared `.rbs` type files (used by `# @rbs import`).
+    pub fn set_shared_paths(&mut self, paths: Vec<std::path::PathBuf>) {
+        self.shared_paths = paths;
+    }
+
+    /// Resolve `# @rbs import <name>` by searching shared_paths for `<name>.rbs`,
+    /// reading its contents, and returning the type aliases found inside.
+    fn resolve_import(shared_paths: &[std::path::PathBuf], name: &str) -> Vec<String> {
+        for dir in shared_paths {
+            let file = dir.join(format!("{}.rbs", name));
+            if let Ok(contents) = fs::read_to_string(&file) {
+                return Self::parse_shared_rbs(&contents);
+            }
+        }
+        eprintln!("  [import] Could not resolve '{}' from shared paths", name);
+        Vec::new()
+    }
+
+    /// Parse a bare `.rbs` file from `sig/shared/` and extract type alias definitions.
+    /// Expected format: `type foo = { ... }` (may span multiple lines).
+    /// Strips `@desc(...)` and similar annotations before returning.
+    fn parse_shared_rbs(contents: &str) -> Vec<String> {
+        let mut aliases = Vec::new();
+        let mut current: Option<String> = None;
+
+        let finalize = |raw: String, out: &mut Vec<String>| {
+            if Self::is_balanced(&raw) {
+                let stripped = Self::strip_annotations(&raw);
+                out.push(format!("type {}", stripped));
+            }
+        };
+
+        for line in contents.lines() {
+            let trimmed = line.trim();
+
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
+
+            if let Some(rest) = trimmed.strip_prefix("type ") {
+                if let Some(prev) = current.take() {
+                    finalize(prev, &mut aliases);
+                }
+                current = Some(rest.to_string());
+            } else if let Some(ref mut cur) = current {
+                cur.push(' ');
+                cur.push_str(trimmed);
+            }
+        }
+
+        if let Some(prev) = current {
+            finalize(prev, &mut aliases);
+        }
+
+        aliases
     }
 
     /// Extract the text of a node from source
@@ -149,7 +210,7 @@ impl SentinelTranspiler {
     }
 
     /// Collect structure from the AST: module nesting, class name, and annotated methods.
-    fn collect_structure(source: &str, root: Node) -> ClassInfo {
+    fn collect_structure(source: &str, root: Node, shared_paths: &[std::path::PathBuf]) -> ClassInfo {
         let mut module_stack = Vec::new();
         let mut info = ClassInfo {
             modules: Vec::new(),
@@ -160,7 +221,7 @@ impl SentinelTranspiler {
             type_aliases: Vec::new(),
             attributes: Vec::new(),
         };
-        Self::walk(source, root, &mut module_stack, &mut info);
+        Self::walk(source, root, &mut module_stack, &mut info, shared_paths);
         info
     }
 
@@ -187,6 +248,7 @@ impl SentinelTranspiler {
         children: &[Node],
         info: &mut ClassInfo,
         singleton_context: bool,
+        shared_paths: &[std::path::PathBuf],
     ) {
         let mut pending_annotation: Option<String> = None;
         let mut pending_type_alias: Option<String> = None;
@@ -229,6 +291,14 @@ impl SentinelTranspiler {
                     // Check for @rbs type alias
                     if let Some(rest) = text.strip_prefix("# @rbs type ") {
                         pending_type_alias = Some(rest.trim().to_string());
+                        pending_annotation = None;
+                    } else if let Some(name) = text.strip_prefix("# @rbs import ") {
+                        // Import shared type(s) from sig/shared/<name>.rbs
+                        let name = name.trim();
+                        let imported = Self::resolve_import(shared_paths, name);
+                        for alias in imported {
+                            info.type_aliases.push(alias);
+                        }
                         pending_annotation = None;
                     } else if let Some(ref mut alias) = pending_type_alias {
                         // Continue multi-line type alias
@@ -288,7 +358,7 @@ impl SentinelTranspiler {
                 "singleton_class" => {
                     // class << self — methods inside are class methods
                     let inner_children = Self::flatten_children(child);
-                    Self::scan_body(source, &inner_children, info, true);
+                    Self::scan_body(source, &inner_children, info, true, shared_paths);
                     pending_annotation = None;
                     pending_type_alias = None;
                 }
@@ -352,6 +422,7 @@ impl SentinelTranspiler {
         node: Node,
         module_stack: &mut Vec<String>,
         info: &mut ClassInfo,
+        shared_paths: &[std::path::PathBuf],
     ) {
         match node.kind() {
             "module" => {
@@ -365,14 +436,14 @@ impl SentinelTranspiler {
 
                     let mut cursor = node.walk();
                     for child in node.children(&mut cursor) {
-                        Self::walk(source, child, module_stack, info);
+                        Self::walk(source, child, module_stack, info, shared_paths);
                     }
 
                     // If no class was found inside, check if this module
                     // itself contains annotated content (e.g. concerns)
                     if info.class_name == "UnknownClass" {
                         let children = Self::flatten_children(node);
-                        Self::scan_body(source, &children, info, false);
+                        Self::scan_body(source, &children, info, false, shared_paths);
                         if !info.methods.is_empty()
                             || !info.self_methods.is_empty()
                             || !info.type_aliases.is_empty()
@@ -411,7 +482,7 @@ impl SentinelTranspiler {
 
                 // Flatten direct children + body_statement children, then scan
                 let children = Self::flatten_children(node);
-                Self::scan_body(source, &children, info, false);
+                Self::scan_body(source, &children, info, false, shared_paths);
 
                 return;
             }
@@ -420,7 +491,7 @@ impl SentinelTranspiler {
 
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
-            Self::walk(source, child, module_stack, info);
+            Self::walk(source, child, module_stack, info, shared_paths);
         }
     }
 
@@ -556,7 +627,7 @@ impl SentinelTranspiler {
         let source = fs::read_to_string(rb_path)?;
         let tree = self.parser.parse(&source, None).ok_or("Failed to parse")?;
 
-        let info = Self::collect_structure(&source, tree.root_node());
+        let info = Self::collect_structure(&source, tree.root_node(), &self.shared_paths);
 
         let mut rbs_output = String::new();
         rbs_output.push_str("# Generated by Sentinel - Do not edit manually\n\n");

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -14,6 +14,7 @@ pub struct SentinelWatcher {
     receiver: mpsc::Receiver<notify::Result<notify::Event>>,
     app_roots: Vec<PathBuf>,
     output_path: PathBuf,
+    shared_paths: Vec<PathBuf>,
     plugins: Vec<Box<dyn SentinelPlugin>>,
 }
 
@@ -41,6 +42,7 @@ impl SentinelWatcher {
             receiver: rx,
             app_roots,
             output_path: config.output_path(),
+            shared_paths: config.shared_type_paths(),
             plugins: Vec::new(),
         })
     }
@@ -68,6 +70,7 @@ impl SentinelWatcher {
     /// The main event loop that processes file changes and triggers transpilation
     pub async fn run(mut self) {
         let mut transpiler = SentinelTranspiler::new();
+        transpiler.set_shared_paths(self.shared_paths.clone());
         for root in &self.app_roots {
             println!("🚀 Sentinel standing guard over {:?}...", root);
         }


### PR DESCRIPTION
## Summary

- Teaches sentinel to resolve `# @rbs import <name>` by reading `sig/shared/<name>.rbs`, parsing bare RBS type definitions, stripping annotations, and inlining them into the generated `.rbs` output
- Adds `shared_paths` config key (default: `["sig/shared"]`) to `.sentinel.toml` — backward-compatible via `serde(default)`
- Threads shared paths through `init`, `check`, `watch`, and the transpiler

## Motivation

`mcp_authorization` (gem) already supports `# @rbs import` for schema compilation. Sentinel was the only tool in the chain that didn't understand it, causing Steep to fail with "Unknown alias name" when handlers used `# @rbs import error` instead of duplicating the type inline.

This enables DRY shared types — define once in `sig/shared/error.rbs`, import in N handlers.

## Files changed

| File | Change |
|---|---|
| `config.rs` | `shared_paths` field + `shared_type_paths()` helper |
| `transpiler.rs` | `resolve_import()`, `parse_shared_rbs()`, `# @rbs import` handler in `scan_body` |
| `init.rs` | Pass `shared_paths` to transpiler |
| `check.rs` | Pass `shared_paths` to transpiler |
| `main.rs` | Read `shared_type_paths()` from config, pass to init/check/watch |
| `watcher.rs` | Store and pass `shared_paths` to transpiler |

## Testing

Tested against the Fountain Hire monolith (172 generated RBS files, 0 errors) + Steep type check passes with zero type errors.

