### PR TITLE
Support sub-modules in RBS generation (e.g. module ClassMethods)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.1] - 2026-05-08
+
+### Fixed
+- **Sub-module RBS generation for concerns**: When a Ruby module contains both annotated methods and a nested module (e.g. `module ClassMethods` inside `McpMigrated`), sentinel now emits both the parent module's methods and the nested module in the generated `.rbs` output. Previously, the nested module's capture would shadow the parent, silently dropping the parent's methods (e.g. `initialize`). Discovered via `Tool::Concerns::McpMigrated` in the Hire monolith, which uses a plain-Ruby `def self.included(base)` pattern with `module ClassMethods`. (#19)
+
 ## [0.4.0] - 2026-05-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sentinel-rb"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentinel-rb"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 authors = ["Andy Gauger <https://github.com/andygauge>"]
 description = "High-speed Rust sidecar for Ruby Type-Safety and Agentic Orchestration"

--- a/src/transpiler.rs
+++ b/src/transpiler.rs
@@ -6,6 +6,14 @@ use tree_sitter::{Node, Parser};
 /// are emitted on multiple lines in the generated `.rbs` output.
 const MULTILINE_THRESHOLD: usize = 3;
 
+struct SubModuleInfo {
+    name: String,
+    methods: Vec<(String, String)>,
+    self_methods: Vec<(String, String)>,
+    type_aliases: Vec<String>,
+    attributes: Vec<(String, String, String)>,
+}
+
 struct ClassInfo {
     modules: Vec<String>,
     class_name: String,
@@ -14,6 +22,7 @@ struct ClassInfo {
     self_methods: Vec<(String, String)>,
     type_aliases: Vec<String>,
     attributes: Vec<(String, String, String)>, // (attr_kind, attr_name, type)
+    sub_modules: Vec<SubModuleInfo>,
 }
 
 pub struct SentinelTranspiler {
@@ -220,6 +229,7 @@ impl SentinelTranspiler {
             self_methods: Vec::new(),
             type_aliases: Vec::new(),
             attributes: Vec::new(),
+            sub_modules: Vec::new(),
         };
         Self::walk(source, root, &mut module_stack, &mut info, shared_paths);
         info
@@ -457,6 +467,50 @@ impl SentinelTranspiler {
                             info.is_module = true;
                             return;
                         }
+                    } else if info.is_module {
+                        // A nested module (e.g. ClassMethods) was already captured.
+                        // Check if the parent module also has its own annotated methods.
+                        // If so, demote the nested module to a sub_module and promote
+                        // the parent as the primary module.
+                        let mut parent_info = ClassInfo {
+                            modules: Vec::new(),
+                            class_name: "UnknownClass".to_string(),
+                            is_module: false,
+                            methods: Vec::new(),
+                            self_methods: Vec::new(),
+                            type_aliases: Vec::new(),
+                            attributes: Vec::new(),
+                            sub_modules: Vec::new(),
+                        };
+                        let children = Self::flatten_children(node);
+                        Self::scan_body(source, &children, &mut parent_info, false);
+                        if !parent_info.methods.is_empty()
+                            || !parent_info.self_methods.is_empty()
+                            || !parent_info.type_aliases.is_empty()
+                            || !parent_info.attributes.is_empty()
+                        {
+                            // Move the previously captured nested module into sub_modules
+                            let nested = SubModuleInfo {
+                                name: info.class_name.clone(),
+                                methods: info.methods.drain(..).collect(),
+                                self_methods: info.self_methods.drain(..).collect(),
+                                type_aliases: info.type_aliases.drain(..).collect(),
+                                attributes: info.attributes.drain(..).collect(),
+                            };
+                            info.sub_modules.push(nested);
+                            // Replace with parent module's content
+                            info.methods = parent_info.methods;
+                            info.self_methods = parent_info.self_methods;
+                            info.type_aliases = parent_info.type_aliases;
+                            info.attributes = parent_info.attributes;
+                            for _ in 0..pushed {
+                                module_stack.pop();
+                            }
+                            info.modules = module_stack.clone();
+                            info.class_name = name.to_string();
+                            info.is_module = true;
+                            return;
+                        }
                     }
 
                     for _ in 0..pushed {
@@ -684,6 +738,51 @@ impl SentinelTranspiler {
             let param_indent = format!("{}  ", member_indent);
             let formatted_sig = Self::maybe_format_sig(sig, &param_indent, &member_indent);
             rbs_output.push_str(&format!("{}def {}: {}\n", member_indent, name, formatted_sig));
+        }
+
+        // Sub-modules (e.g. ClassMethods inside a concern)
+        for sub in &info.sub_modules {
+            let sub_indent = "  ".repeat(depth + 1);
+            let sub_member_indent = "  ".repeat(depth + 2);
+            rbs_output.push_str(&format!("{}module {}\n", sub_indent, sub.name));
+            for alias in &sub.type_aliases {
+                let formatted = if let Some(eq_pos) = alias.find(" = ") {
+                    let lhs = &alias[..eq_pos + 3];
+                    let rhs = alias[eq_pos + 3..].trim();
+                    let field_indent = format!("{}  ", sub_member_indent);
+                    let formatted_rhs =
+                        Self::maybe_format_record(rhs, &field_indent, &sub_member_indent);
+                    format!("{}{}", lhs, formatted_rhs)
+                } else {
+                    alias.clone()
+                };
+                rbs_output.push_str(&format!("{}{}\n", sub_member_indent, formatted));
+            }
+            for (kind, name, type_sig) in &sub.attributes {
+                rbs_output.push_str(&format!(
+                    "{}{} {}: {}\n",
+                    sub_member_indent, kind, name, type_sig
+                ));
+            }
+            for (name, sig) in &sub.self_methods {
+                let param_indent = format!("{}  ", sub_member_indent);
+                let formatted_sig =
+                    Self::maybe_format_sig(sig, &param_indent, &sub_member_indent);
+                rbs_output.push_str(&format!(
+                    "{}def self.{}: {}\n",
+                    sub_member_indent, name, formatted_sig
+                ));
+            }
+            for (name, sig) in &sub.methods {
+                let param_indent = format!("{}  ", sub_member_indent);
+                let formatted_sig =
+                    Self::maybe_format_sig(sig, &param_indent, &sub_member_indent);
+                rbs_output.push_str(&format!(
+                    "{}def {}: {}\n",
+                    sub_member_indent, name, formatted_sig
+                ));
+            }
+            rbs_output.push_str(&format!("{}end\n", sub_indent));
         }
 
         rbs_output.push_str(&format!("{}end\n", class_indent));
@@ -1410,6 +1509,65 @@ end
         assert!(
             result.contains("def perform: () -> void"),
             "Expected Service's method, got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_module_with_sub_module_class_methods() {
+        let test_file = Path::new("/tmp/test_module_sub_module.rb");
+        fs::write(
+            test_file,
+            "\
+module Tool
+  module Concerns
+    module McpMigrated
+      #: (server_context: untyped) -> void
+      def initialize(server_context:)
+      end
+
+      module ClassMethods
+        #: (current_user: untyped, current_account: untyped, params: untyped) -> instance
+        def from_legacy(current_user:, current_account:, params:)
+        end
+      end
+    end
+  end
+end
+",
+        )
+        .unwrap();
+
+        let mut transpiler = SentinelTranspiler::new();
+        let result = transpiler.transpile_file(test_file).unwrap();
+        assert!(
+            result.contains("module Tool\n"),
+            "Expected module Tool, got: {}",
+            result
+        );
+        assert!(
+            result.contains("  module Concerns\n"),
+            "Expected module Concerns, got: {}",
+            result
+        );
+        assert!(
+            result.contains("    module McpMigrated\n"),
+            "Expected module McpMigrated, got: {}",
+            result
+        );
+        assert!(
+            result.contains("def initialize: (server_context: untyped) -> void"),
+            "Expected initialize method on parent module, got: {}",
+            result
+        );
+        assert!(
+            result.contains("module ClassMethods\n"),
+            "Expected ClassMethods sub-module, got: {}",
+            result
+        );
+        assert!(
+            result.contains("def from_legacy: (current_user: untyped, current_account: untyped, params: untyped) -> instance"),
+            "Expected from_legacy in ClassMethods, got: {}",
             result
         );
     }

--- a/src/transpiler.rs
+++ b/src/transpiler.rs
@@ -483,7 +483,7 @@ impl SentinelTranspiler {
                             sub_modules: Vec::new(),
                         };
                         let children = Self::flatten_children(node);
-                        Self::scan_body(source, &children, &mut parent_info, false);
+                        Self::scan_body(source, &children, &mut parent_info, false, shared_paths);
                         if !parent_info.methods.is_empty()
                             || !parent_info.self_methods.is_empty()
                             || !parent_info.type_aliases.is_empty()


### PR DESCRIPTION
## Summary

When a module contains both annotated instance methods and an annotated nested module (e.g. `ClassMethods`), Sentinel now emits both in the generated RBS.

**Before (stock 0.4.0)**: Only the nested module was captured — the parent module's methods were silently dropped.

```rbs
module McpMigrated
  module ClassMethods
    def from_legacy: (...) -> instance
  end
end
# initialize is missing!
```

**After (0.4.1)**: Parent module methods are top-level members, nested modules appear as sub-modules:

```rbs
module McpMigrated
  def initialize: (server_context: untyped) -> void
  module ClassMethods
    def from_legacy: (current_user: untyped, current_account: untyped, params: untyped) -> instance
  end
end
```

## Changes

- Add `SubModuleInfo` struct (with all member types: methods, self_methods, type_aliases, attributes) and `sub_modules` field to `ClassInfo`
- In `walk()`, when a nested module was already captured and the parent also has annotated methods, demote the nested module to a sub-module and promote the parent
- In `transpile_file()`, emit sub-modules after instance methods
- Add `test_module_with_sub_module_class_methods` test
- Bump to 0.4.1, add CHANGELOG entry

## Rebased onto master (0.4.0)

This PR is now based on current master. The diff is **purely additive** — 165 insertions, 2 changes (version bump), 0 deletions. All `# @rbs import` functionality from 0.4.0 is preserved.

## Context

Discovered while extracting a shared `McpMigrated` concern in the Hire monolith ([monolith#36219](https://github.com/onboardiq/monolith/pull/36219)). The concern uses `def self.included(base)` + `module ClassMethods` (plain Ruby, to avoid Steep errors with AS::Concern's `included do` macro). Without this fix, Sentinel drops `initialize` from the generated RBS.

## Test plan

- [x] `cargo test` — 52 tests pass, 0 failures
- [x] Compared stock 0.4.0 vs 0.4.1 against actual `mcp_migrated.rb` — stock drops `initialize`, fix generates both
- [x] `git diff upstream/master --stat` — 4 files, +165/-2, zero deletions

🤖 Generated with [Claude Code](https://claude.com/claude-code)