### PR TITLE
Recursive import resolution for nested type references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [0.4.2] - 2026-05-11
+
+### Added
+- **Recursive import resolution**: `# @rbs import` now recursively resolves nested type references. When an imported type references other types defined in `sig/shared/`, those dependencies are automatically resolved, stripped of MCP annotations, and inlined in the generated `.rbs` output — emitted before the types that reference them. Cycle detection prevents infinite loops. Previously, only the directly imported type was expanded; nested references were left as bare names, causing Steep `RBS::UnknownTypeName` errors. (#21)
+
+  ```ruby
+  # sig/shared/funnel.rbs
+  type stage_ref = { id: String @desc(Stage ID), title: String }
+
+  # sig/shared/funnel_result.rbs
+  type funnel_result = { title: String, ?stages: Array[stage_ref] }
+  ```
+
+  ```ruby
+  # app/services/tool/get_funnel.rb
+  # @rbs import funnel_result   # ← only imports the top-level type
+  ```
+
+  Before (0.4.1): `stage_ref` left as bare name → Steep error
+  ```rbs
+  type funnel_result = { title: String, ?stages: Array[stage_ref] }
+  ```
+
+  After (0.4.2): `stage_ref` automatically resolved and emitted first
+  ```rbs
+  type stage_ref = {id: String, title: String}
+  type funnel_result = { title: String, ?stages: Array[stage_ref] }
+  ```
+
+- **Cross-file type lookup**: `resolve_single_import` now falls back to scanning all `.rbs` files in `shared_paths` when the type name doesn't match a filename. This supports types co-located in a single file (e.g. `stage_ref` defined in `funnel.rbs`).
+
 ## [0.4.1] - 2026-05-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "filetime"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +131,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,10 +146,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
@@ -146,7 +192,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -170,6 +218,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +244,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,6 +266,12 @@ dependencies = [
  "plain",
  "redox_syscall 0.7.3",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -271,6 +337,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +378,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +404,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rayon"
@@ -391,6 +479,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,6 +507,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "sentinel-rb"
 version = "0.4.2"
 dependencies = [
@@ -413,6 +520,7 @@ dependencies = [
  "notify",
  "rayon",
  "serde",
+ "tempfile",
  "tokio",
  "toml",
  "tree-sitter",
@@ -448,6 +556,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -500,6 +621,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -598,6 +732,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +752,58 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "winapi-util"
@@ -711,3 +903,103 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sentinel-rb"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentinel-rb"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 authors = ["Andy Gauger <https://github.com/andygauge>"]
 description = "High-speed Rust sidecar for Ruby Type-Safety and Agentic Orchestration"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ toml = "0.8"
 
 # Errors
 anyhow = "1.0"
+
+[dev-dependencies]
+tempfile = "3"

--- a/sentinel-gem/rbs-sentinel.gemspec
+++ b/sentinel-gem/rbs-sentinel.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "rbs-sentinel"
-  spec.version       = "0.4.1"
+  spec.version       = "0.4.2"
   spec.executables   = ["sentinel"]
   spec.bindir        = "bin"
   spec.authors       = ["Andrew Gauger"]

--- a/src/transpiler.rs
+++ b/src/transpiler.rs
@@ -101,8 +101,22 @@ impl SentinelTranspiler {
             }
         }
 
-        // Add our aliases after dependencies (so referenced types are defined first)
-        resolved.extend(aliases);
+        // Add our aliases after dependencies, skipping any already emitted
+        // (can happen when an exact-file match returns multiple types and one
+        // was already resolved via a recursive call from a sibling alias).
+        for alias in aliases {
+            let name = alias
+                .strip_prefix("type ")
+                .and_then(|rest| rest.split_whitespace().next())
+                .unwrap_or("");
+            if !resolved.iter().any(|r| {
+                r.strip_prefix("type ")
+                    .and_then(|rest| rest.split_whitespace().next())
+                    .map_or(false, |n| n == name)
+            }) {
+                resolved.push(alias);
+            }
+        }
     }
 
     /// Resolve a single import by name. First tries `<name>.rbs` (exact file match),
@@ -2255,6 +2269,10 @@ end
 
         assert!(result.contains("type inner ="), "Expected inner, got: {}", result);
         assert!(result.contains("type bundle ="), "Expected bundle, got: {}", result);
+
+        // No duplicates — inner should appear exactly once
+        let count = result.matches("type inner =").count();
+        assert_eq!(count, 1, "Expected inner exactly once, found {} times in: {}", count, result);
     }
 
     #[test]

--- a/src/transpiler.rs
+++ b/src/transpiler.rs
@@ -71,8 +71,8 @@ impl SentinelTranspiler {
         seen: &mut std::collections::HashSet<String>,
         available: &std::collections::HashSet<String>,
     ) {
-        // Insert before resolution so that even if the type can't be found,
-        // we won't spam repeated "Could not resolve" warnings for the same name.
+        // Insert before resolution for cycle detection and to suppress
+        // repeated "Could not resolve" warnings for the same name.
         if !seen.insert(name.to_string()) {
             return; // already resolved or in progress — avoid cycles
         }
@@ -83,18 +83,10 @@ impl SentinelTranspiler {
             return;
         }
 
-        // Mark every co-located type as seen so the reference loop below
-        // won't recurse into them — this call will emit them in its final extend.
-        for alias in &aliases {
-            if let Some(defined) = alias
-                .strip_prefix("type ")
-                .and_then(|rest| rest.split_whitespace().next())
-            {
-                seen.insert(defined.to_string());
-            }
-        }
-
-        // Scan the aliases for references to other shared types
+        // Scan the aliases for references to other shared types.
+        // Co-located types (same file) are NOT pre-marked in seen, so if alias A
+        // references co-located alias B, the recursion resolves and emits B first,
+        // guaranteeing topological order regardless of file order.
         for alias in &aliases {
             let defined_name = alias
                 .strip_prefix("type ")
@@ -110,8 +102,19 @@ impl SentinelTranspiler {
             }
         }
 
-        // Add our aliases after dependencies (so referenced types are defined first)
-        resolved.extend(aliases);
+        // Emit aliases, skipping co-located types already emitted by recursive calls.
+        // The primary type (name) was inserted into seen at entry — use defined == name
+        // to ensure it's always emitted. For co-located types, seen.insert returns false
+        // if already resolved above, preventing duplicates.
+        for alias in aliases {
+            let defined = alias
+                .strip_prefix("type ")
+                .and_then(|rest| rest.split_whitespace().next())
+                .unwrap_or("");
+            if defined == name || seen.insert(defined.to_string()) {
+                resolved.push(alias);
+            }
+        }
     }
 
     /// Resolve a single import by name. First tries `<name>.rbs` (exact file match),
@@ -2268,6 +2271,37 @@ end
         // No duplicates — inner should appear exactly once
         let count = result.matches("type inner =").count();
         assert_eq!(count, 1, "Expected inner exactly once, found {} times in: {}", count, result);
+    }
+
+    #[test]
+    fn test_colocated_types_reversed_file_order() {
+        let tmp = TempDir::new().unwrap();
+        let shared_dir = tmp.path().join("shared");
+        fs::create_dir_all(&shared_dir).unwrap();
+
+        // bundle is defined BEFORE inner in the file — dependency order is reversed
+        fs::write(
+            shared_dir.join("bundle.rbs"),
+            "type bundle = { item: inner }\n\ntype inner = { id: String }\n",
+        ).unwrap();
+
+        let test_file = tmp.path().join("test.rb");
+        fs::write(
+            &test_file,
+            "class Foo\n  # @rbs import bundle\n\n  #: () -> bundle\n  def call\n  end\nend\n",
+        ).unwrap();
+
+        let mut transpiler = SentinelTranspiler::new();
+        transpiler.set_shared_paths(vec![shared_dir.clone()]);
+        let result = transpiler.transpile_file(&test_file).unwrap();
+
+        assert!(result.contains("type inner ="), "Expected inner, got: {}", result);
+        assert!(result.contains("type bundle ="), "Expected bundle, got: {}", result);
+
+        // inner must appear before bundle even though file order is reversed
+        let inner_pos = result.find("type inner =").unwrap();
+        let bundle_pos = result.find("type bundle =").unwrap();
+        assert!(inner_pos < bundle_pos, "inner should appear before bundle (dependency order), got: {}", result);
     }
 
     #[test]

--- a/src/transpiler.rs
+++ b/src/transpiler.rs
@@ -59,7 +59,7 @@ impl SentinelTranspiler {
         let mut seen = std::collections::HashSet::new();
         // Build the index of all available type names once, then pass it through
         // the recursion so we don't re-read every .rbs file at each level of DFS.
-        let available = Self::index_shared_types(shared_paths);
+        let available: std::collections::BTreeSet<String> = Self::index_shared_types(shared_paths);
         Self::resolve_import_recursive(shared_paths, name, &mut resolved, &mut seen, &available);
         resolved
     }
@@ -69,7 +69,7 @@ impl SentinelTranspiler {
         name: &str,
         resolved: &mut Vec<String>,
         seen: &mut std::collections::HashSet<String>,
-        available: &std::collections::HashSet<String>,
+        available: &std::collections::BTreeSet<String>,
     ) {
         // Insert before resolution for cycle detection and to suppress
         // repeated "Could not resolve" warnings for the same name.
@@ -160,8 +160,8 @@ impl SentinelTranspiler {
     }
 
     /// Collect all type names defined across all `.rbs` files in shared_paths.
-    fn index_shared_types(shared_paths: &[std::path::PathBuf]) -> std::collections::HashSet<String> {
-        let mut names = std::collections::HashSet::new();
+    fn index_shared_types(shared_paths: &[std::path::PathBuf]) -> std::collections::BTreeSet<String> {
+        let mut names = std::collections::BTreeSet::new();
         for dir in shared_paths {
             if let Ok(entries) = fs::read_dir(dir) {
                 for entry in entries.flatten() {

--- a/src/transpiler.rs
+++ b/src/transpiler.rs
@@ -51,15 +51,153 @@ impl SentinelTranspiler {
 
     /// Resolve `# @rbs import <name>` by searching shared_paths for `<name>.rbs`,
     /// reading its contents, and returning the type aliases found inside.
+    /// Recursively resolves nested type references: if an imported type references
+    /// another type defined in `sig/shared/`, that type is also imported.
     fn resolve_import(shared_paths: &[std::path::PathBuf], name: &str) -> Vec<String> {
+        let mut resolved: Vec<String> = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        Self::resolve_import_recursive(shared_paths, name, &mut resolved, &mut seen);
+        resolved
+    }
+
+    fn resolve_import_recursive(
+        shared_paths: &[std::path::PathBuf],
+        name: &str,
+        resolved: &mut Vec<String>,
+        seen: &mut std::collections::HashSet<String>,
+    ) {
+        if !seen.insert(name.to_string()) {
+            return; // already resolved — avoid cycles
+        }
+
+        // Find and parse the requested type file
+        let aliases = Self::resolve_single_import(shared_paths, name);
+        if aliases.is_empty() {
+            return;
+        }
+
+        // Build an index of all available type names across shared_paths
+        let available = Self::index_shared_types(shared_paths);
+
+        // Scan the aliases for references to other shared types
+        for alias in &aliases {
+            // Extract the type name being defined (e.g. "foo" from "type foo = { ... }")
+            let defined_name = alias
+                .strip_prefix("type ")
+                .and_then(|rest| rest.split_whitespace().next())
+                .unwrap_or("");
+
+            for available_name in &available {
+                if available_name != defined_name && !seen.contains(available_name) {
+                    // Check if this available type name appears in the alias body
+                    if Self::references_type(alias, available_name) {
+                        Self::resolve_import_recursive(shared_paths, available_name, resolved, seen);
+                    }
+                }
+            }
+        }
+
+        // Add our aliases after dependencies (so referenced types are defined first)
+        resolved.extend(aliases);
+    }
+
+    /// Resolve a single import by name. First tries `<name>.rbs` (exact file match),
+    /// then scans all `.rbs` files for a `type <name> = ...` definition.
+    fn resolve_single_import(shared_paths: &[std::path::PathBuf], name: &str) -> Vec<String> {
+        // 1. Try exact file match: sig/shared/<name>.rbs
         for dir in shared_paths {
             let file = dir.join(format!("{}.rbs", name));
             if let Ok(contents) = fs::read_to_string(&file) {
                 return Self::parse_shared_rbs(&contents);
             }
         }
+
+        // 2. Scan all .rbs files for a type definition matching the name
+        let target_prefix = format!("{} =", name);
+        for dir in shared_paths {
+            if let Ok(entries) = fs::read_dir(dir) {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.extension().map_or(false, |e| e == "rbs") {
+                        if let Ok(contents) = fs::read_to_string(&path) {
+                            // Check if this file defines the type we're looking for
+                            let has_type = contents.lines().any(|line| {
+                                line.trim()
+                                    .strip_prefix("type ")
+                                    .map_or(false, |rest| rest.starts_with(&target_prefix))
+                            });
+                            if has_type {
+                                // Parse and return only the matching type(s)
+                                let all_aliases = Self::parse_shared_rbs(&contents);
+                                let matching: Vec<String> = all_aliases
+                                    .into_iter()
+                                    .filter(|a| {
+                                        a.strip_prefix("type ")
+                                            .map_or(false, |rest| rest.starts_with(&target_prefix))
+                                    })
+                                    .collect();
+                                if !matching.is_empty() {
+                                    return matching;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         eprintln!("  [import] Could not resolve '{}' from shared paths", name);
         Vec::new()
+    }
+
+    /// Collect all type names defined across all `.rbs` files in shared_paths.
+    fn index_shared_types(shared_paths: &[std::path::PathBuf]) -> Vec<String> {
+        let mut names = Vec::new();
+        for dir in shared_paths {
+            if let Ok(entries) = fs::read_dir(dir) {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.extension().map_or(false, |e| e == "rbs") {
+                        if let Ok(contents) = fs::read_to_string(&path) {
+                            for line in contents.lines() {
+                                let trimmed = line.trim();
+                                if let Some(rest) = trimmed.strip_prefix("type ") {
+                                    if let Some(name) = rest.split_whitespace().next() {
+                                        names.push(name.to_string());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        names
+    }
+
+    /// Check whether an alias body references a given type name.
+    /// Matches the name as a whole word (not as a substring of another identifier).
+    fn references_type(alias: &str, type_name: &str) -> bool {
+        let name_bytes = type_name.as_bytes();
+        let alias_bytes = alias.as_bytes();
+        let name_len = name_bytes.len();
+
+        let mut i = 0;
+        while i + name_len <= alias_bytes.len() {
+            if &alias_bytes[i..i + name_len] == name_bytes {
+                // Check word boundary before
+                let before_ok = i == 0 || !alias_bytes[i - 1].is_ascii_alphanumeric() && alias_bytes[i - 1] != b'_';
+                // Check word boundary after
+                let after_pos = i + name_len;
+                let after_ok = after_pos >= alias_bytes.len()
+                    || !alias_bytes[after_pos].is_ascii_alphanumeric() && alias_bytes[after_pos] != b'_';
+                if before_ok && after_ok {
+                    return true;
+                }
+            }
+            i += 1;
+        }
+        false
     }
 
     /// Parse a bare `.rbs` file from `sig/shared/` and extract type alias definitions.
@@ -2028,5 +2166,159 @@ end
                 "other: { a: String, b: Integer }",
             ]
         );
+    }
+
+    #[test]
+    fn test_recursive_import_resolves_nested_types() {
+        // Set up shared type files in a temp directory
+        let shared_dir = Path::new("/tmp/test_shared_recursive");
+        let _ = fs::create_dir_all(shared_dir);
+
+        // A sub-type in its own file
+        fs::write(
+            shared_dir.join("stage_ref.rbs"),
+            "type stage_ref = {\n  id: String @desc(Stage ID),\n  title: String\n}\n",
+        ).unwrap();
+
+        // Another sub-type in a different file
+        fs::write(
+            shared_dir.join("owner_ref.rbs"),
+            "type owner_ref = {\n  name: String,\n  email: String @format(email)\n}\n",
+        ).unwrap();
+
+        // Main type that references both sub-types
+        fs::write(
+            shared_dir.join("funnel_result.rbs"),
+            "type funnel_result = {\n  title: String,\n  ?stages: Array[stage_ref],\n  ?owner: owner_ref\n}\n",
+        ).unwrap();
+
+        // Ruby handler that imports only the main type
+        let test_file = Path::new("/tmp/test_recursive_import.rb");
+        fs::write(
+            test_file,
+            "module Tool\n  class GetFunnel\n    # @rbs import funnel_result\n\n    # @rbs type success = {\n    #   success: true,\n    #   funnel: funnel_result\n    # }\n\n    #: () -> success\n    def call\n    end\n  end\nend\n",
+        ).unwrap();
+
+        let mut transpiler = SentinelTranspiler::new();
+        transpiler.set_shared_paths(vec![shared_dir.to_path_buf()]);
+        let result = transpiler.transpile_file(test_file).unwrap();
+
+        // The main type should be expanded
+        assert!(
+            result.contains("type funnel_result ="),
+            "Expected funnel_result type, got: {}", result
+        );
+
+        // The nested types should also be resolved and expanded
+        assert!(
+            result.contains("type stage_ref ="),
+            "Expected stage_ref to be recursively resolved, got: {}", result
+        );
+        assert!(
+            result.contains("type owner_ref ="),
+            "Expected owner_ref to be recursively resolved, got: {}", result
+        );
+
+        // Annotations should be stripped
+        assert!(
+            !result.contains("@desc"),
+            "Expected annotations to be stripped, got: {}", result
+        );
+        assert!(
+            !result.contains("@format"),
+            "Expected annotations to be stripped, got: {}", result
+        );
+
+        // Dependencies should appear before the type that references them
+        let stage_pos = result.find("type stage_ref =").unwrap();
+        let owner_pos = result.find("type owner_ref =").unwrap();
+        let funnel_pos = result.find("type funnel_result =").unwrap();
+        assert!(
+            stage_pos < funnel_pos,
+            "stage_ref should appear before funnel_result"
+        );
+        assert!(
+            owner_pos < funnel_pos,
+            "owner_ref should appear before funnel_result"
+        );
+
+        // Cleanup
+        let _ = fs::remove_dir_all(shared_dir);
+        let _ = fs::remove_file(test_file);
+    }
+
+    #[test]
+    fn test_recursive_import_no_cycles() {
+        let shared_dir = Path::new("/tmp/test_shared_cycles");
+        let _ = fs::create_dir_all(shared_dir);
+
+        // Type A references type B
+        fs::write(
+            shared_dir.join("type_a.rbs"),
+            "type type_a = { ref: type_b }\n",
+        ).unwrap();
+
+        // Type B references type A (cycle)
+        fs::write(
+            shared_dir.join("type_b.rbs"),
+            "type type_b = { ref: type_a }\n",
+        ).unwrap();
+
+        let test_file = Path::new("/tmp/test_cycle_import.rb");
+        fs::write(
+            test_file,
+            "class Foo\n  # @rbs import type_a\n\n  #: () -> type_a\n  def call\n  end\nend\n",
+        ).unwrap();
+
+        let mut transpiler = SentinelTranspiler::new();
+        transpiler.set_shared_paths(vec![shared_dir.to_path_buf()]);
+        let result = transpiler.transpile_file(test_file).unwrap();
+
+        // Both types should be present (no infinite loop)
+        assert!(result.contains("type type_a ="), "Expected type_a, got: {}", result);
+        assert!(result.contains("type type_b ="), "Expected type_b, got: {}", result);
+
+        let _ = fs::remove_dir_all(shared_dir);
+        let _ = fs::remove_file(test_file);
+    }
+
+    #[test]
+    fn test_recursive_import_types_in_same_file() {
+        // When sub-types are in the same file as the main type,
+        // they should already be included (existing behavior)
+        let shared_dir = Path::new("/tmp/test_shared_same_file");
+        let _ = fs::create_dir_all(shared_dir);
+
+        fs::write(
+            shared_dir.join("bundle.rbs"),
+            "type inner = { id: String }\n\ntype bundle = { item: inner }\n",
+        ).unwrap();
+
+        let test_file = Path::new("/tmp/test_same_file_import.rb");
+        fs::write(
+            test_file,
+            "class Foo\n  # @rbs import bundle\n\n  #: () -> bundle\n  def call\n  end\nend\n",
+        ).unwrap();
+
+        let mut transpiler = SentinelTranspiler::new();
+        transpiler.set_shared_paths(vec![shared_dir.to_path_buf()]);
+        let result = transpiler.transpile_file(test_file).unwrap();
+
+        assert!(result.contains("type inner ="), "Expected inner, got: {}", result);
+        assert!(result.contains("type bundle ="), "Expected bundle, got: {}", result);
+
+        let _ = fs::remove_dir_all(shared_dir);
+        let _ = fs::remove_file(test_file);
+    }
+
+    #[test]
+    fn test_references_type_word_boundary() {
+        // "error" should not match "error_code"
+        assert!(SentinelTranspiler::references_type("type foo = { e: error }", "error"));
+        assert!(!SentinelTranspiler::references_type("type foo = { e: error_code }", "error"));
+        assert!(SentinelTranspiler::references_type("type foo = { e: Array[error] }", "error"));
+        assert!(SentinelTranspiler::references_type("type foo = { e: error, f: String }", "error"));
+        // references_type is a pure string check — the caller skips the defined name
+        assert!(SentinelTranspiler::references_type("type error = { code: String }", "error"));
     }
 }

--- a/src/transpiler.rs
+++ b/src/transpiler.rs
@@ -83,9 +83,19 @@ impl SentinelTranspiler {
             return;
         }
 
+        // Mark every co-located type as seen so the reference loop below
+        // won't recurse into them — this call will emit them in its final extend.
+        for alias in &aliases {
+            if let Some(defined) = alias
+                .strip_prefix("type ")
+                .and_then(|rest| rest.split_whitespace().next())
+            {
+                seen.insert(defined.to_string());
+            }
+        }
+
         // Scan the aliases for references to other shared types
         for alias in &aliases {
-            // Extract the type name being defined (e.g. "foo" from "type foo = { ... }")
             let defined_name = alias
                 .strip_prefix("type ")
                 .and_then(|rest| rest.split_whitespace().next())
@@ -93,7 +103,6 @@ impl SentinelTranspiler {
 
             for available_name in available {
                 if available_name != defined_name && !seen.contains(available_name) {
-                    // Check if this available type name appears in the alias body
                     if Self::references_type(alias, available_name) {
                         Self::resolve_import_recursive(shared_paths, available_name, resolved, seen, available);
                     }
@@ -101,22 +110,8 @@ impl SentinelTranspiler {
             }
         }
 
-        // Add our aliases after dependencies, skipping any already emitted
-        // (can happen when an exact-file match returns multiple types and one
-        // was already resolved via a recursive call from a sibling alias).
-        for alias in aliases {
-            let name = alias
-                .strip_prefix("type ")
-                .and_then(|rest| rest.split_whitespace().next())
-                .unwrap_or("");
-            if !resolved.iter().any(|r| {
-                r.strip_prefix("type ")
-                    .and_then(|rest| rest.split_whitespace().next())
-                    .map_or(false, |n| n == name)
-            }) {
-                resolved.push(alias);
-            }
-        }
+        // Add our aliases after dependencies (so referenced types are defined first)
+        resolved.extend(aliases);
     }
 
     /// Resolve a single import by name. First tries `<name>.rbs` (exact file match),

--- a/src/transpiler.rs
+++ b/src/transpiler.rs
@@ -51,12 +51,16 @@ impl SentinelTranspiler {
 
     /// Resolve `# @rbs import <name>` by searching shared_paths for `<name>.rbs`,
     /// reading its contents, and returning the type aliases found inside.
-    /// Recursively resolves nested type references: if an imported type references
-    /// another type defined in `sig/shared/`, that type is also imported.
+    /// Transitively resolves nested type references with cycle detection: if an
+    /// imported type references another type defined in `sig/shared/`, that type
+    /// is also imported. Dependencies are emitted before dependents (reverse-topological order).
     fn resolve_import(shared_paths: &[std::path::PathBuf], name: &str) -> Vec<String> {
         let mut resolved: Vec<String> = Vec::new();
         let mut seen = std::collections::HashSet::new();
-        Self::resolve_import_recursive(shared_paths, name, &mut resolved, &mut seen);
+        // Build the index of all available type names once, then pass it through
+        // the recursion so we don't re-read every .rbs file at each level of DFS.
+        let available = Self::index_shared_types(shared_paths);
+        Self::resolve_import_recursive(shared_paths, name, &mut resolved, &mut seen, &available);
         resolved
     }
 
@@ -65,9 +69,12 @@ impl SentinelTranspiler {
         name: &str,
         resolved: &mut Vec<String>,
         seen: &mut std::collections::HashSet<String>,
+        available: &std::collections::HashSet<String>,
     ) {
+        // Insert before resolution so that even if the type can't be found,
+        // we won't spam repeated "Could not resolve" warnings for the same name.
         if !seen.insert(name.to_string()) {
-            return; // already resolved — avoid cycles
+            return; // already resolved or in progress — avoid cycles
         }
 
         // Find and parse the requested type file
@@ -75,9 +82,6 @@ impl SentinelTranspiler {
         if aliases.is_empty() {
             return;
         }
-
-        // Build an index of all available type names across shared_paths
-        let available = Self::index_shared_types(shared_paths);
 
         // Scan the aliases for references to other shared types
         for alias in &aliases {
@@ -87,11 +91,11 @@ impl SentinelTranspiler {
                 .and_then(|rest| rest.split_whitespace().next())
                 .unwrap_or("");
 
-            for available_name in &available {
+            for available_name in available {
                 if available_name != defined_name && !seen.contains(available_name) {
                     // Check if this available type name appears in the alias body
                     if Self::references_type(alias, available_name) {
-                        Self::resolve_import_recursive(shared_paths, available_name, resolved, seen);
+                        Self::resolve_import_recursive(shared_paths, available_name, resolved, seen, available);
                     }
                 }
             }
@@ -112,7 +116,9 @@ impl SentinelTranspiler {
             }
         }
 
-        // 2. Scan all .rbs files for a type definition matching the name
+        // 2. Scan all .rbs files for a type definition matching the name.
+        //    Parse each file once and filter — avoids reading the same file twice
+        //    (once for the line scan, once for parse_shared_rbs).
         let target_prefix = format!("{} =", name);
         for dir in shared_paths {
             if let Ok(entries) = fs::read_dir(dir) {
@@ -120,25 +126,16 @@ impl SentinelTranspiler {
                     let path = entry.path();
                     if path.extension().map_or(false, |e| e == "rbs") {
                         if let Ok(contents) = fs::read_to_string(&path) {
-                            // Check if this file defines the type we're looking for
-                            let has_type = contents.lines().any(|line| {
-                                line.trim()
-                                    .strip_prefix("type ")
-                                    .map_or(false, |rest| rest.starts_with(&target_prefix))
-                            });
-                            if has_type {
-                                // Parse and return only the matching type(s)
-                                let all_aliases = Self::parse_shared_rbs(&contents);
-                                let matching: Vec<String> = all_aliases
-                                    .into_iter()
-                                    .filter(|a| {
-                                        a.strip_prefix("type ")
-                                            .map_or(false, |rest| rest.starts_with(&target_prefix))
-                                    })
-                                    .collect();
-                                if !matching.is_empty() {
-                                    return matching;
-                                }
+                            let all_aliases = Self::parse_shared_rbs(&contents);
+                            let matching: Vec<String> = all_aliases
+                                .into_iter()
+                                .filter(|a| {
+                                    a.strip_prefix("type ")
+                                        .map_or(false, |rest| rest.starts_with(&target_prefix))
+                                })
+                                .collect();
+                            if !matching.is_empty() {
+                                return matching;
                             }
                         }
                     }
@@ -151,8 +148,8 @@ impl SentinelTranspiler {
     }
 
     /// Collect all type names defined across all `.rbs` files in shared_paths.
-    fn index_shared_types(shared_paths: &[std::path::PathBuf]) -> Vec<String> {
-        let mut names = Vec::new();
+    fn index_shared_types(shared_paths: &[std::path::PathBuf]) -> std::collections::HashSet<String> {
+        let mut names = std::collections::HashSet::new();
         for dir in shared_paths {
             if let Ok(entries) = fs::read_dir(dir) {
                 for entry in entries.flatten() {
@@ -163,7 +160,7 @@ impl SentinelTranspiler {
                                 let trimmed = line.trim();
                                 if let Some(rest) = trimmed.strip_prefix("type ") {
                                     if let Some(name) = rest.split_whitespace().next() {
-                                        names.push(name.to_string());
+                                        names.insert(name.to_string());
                                     }
                                 }
                             }
@@ -186,11 +183,11 @@ impl SentinelTranspiler {
         while i + name_len <= alias_bytes.len() {
             if &alias_bytes[i..i + name_len] == name_bytes {
                 // Check word boundary before
-                let before_ok = i == 0 || !alias_bytes[i - 1].is_ascii_alphanumeric() && alias_bytes[i - 1] != b'_';
+                let before_ok = i == 0 || (!alias_bytes[i - 1].is_ascii_alphanumeric() && alias_bytes[i - 1] != b'_');
                 // Check word boundary after
                 let after_pos = i + name_len;
                 let after_ok = after_pos >= alias_bytes.len()
-                    || !alias_bytes[after_pos].is_ascii_alphanumeric() && alias_bytes[after_pos] != b'_';
+                    || (!alias_bytes[after_pos].is_ascii_alphanumeric() && alias_bytes[after_pos] != b'_');
                 if before_ok && after_ok {
                     return true;
                 }
@@ -938,6 +935,7 @@ impl SentinelTranspiler {
 mod tests {
     use super::*;
     use std::fs;
+    use tempfile::TempDir;
 
     #[test]
     fn test_simple_class_name() {
@@ -2170,155 +2168,101 @@ end
 
     #[test]
     fn test_recursive_import_resolves_nested_types() {
-        // Set up shared type files in a temp directory
-        let shared_dir = Path::new("/tmp/test_shared_recursive");
-        let _ = fs::create_dir_all(shared_dir);
+        let tmp = TempDir::new().unwrap();
+        let shared_dir = tmp.path().join("shared");
+        fs::create_dir_all(&shared_dir).unwrap();
 
-        // A sub-type in its own file
         fs::write(
             shared_dir.join("stage_ref.rbs"),
             "type stage_ref = {\n  id: String @desc(Stage ID),\n  title: String\n}\n",
         ).unwrap();
-
-        // Another sub-type in a different file
         fs::write(
             shared_dir.join("owner_ref.rbs"),
             "type owner_ref = {\n  name: String,\n  email: String @format(email)\n}\n",
         ).unwrap();
-
-        // Main type that references both sub-types
         fs::write(
             shared_dir.join("funnel_result.rbs"),
             "type funnel_result = {\n  title: String,\n  ?stages: Array[stage_ref],\n  ?owner: owner_ref\n}\n",
         ).unwrap();
 
-        // Ruby handler that imports only the main type
-        let test_file = Path::new("/tmp/test_recursive_import.rb");
+        let test_file = tmp.path().join("test.rb");
         fs::write(
-            test_file,
+            &test_file,
             "module Tool\n  class GetFunnel\n    # @rbs import funnel_result\n\n    # @rbs type success = {\n    #   success: true,\n    #   funnel: funnel_result\n    # }\n\n    #: () -> success\n    def call\n    end\n  end\nend\n",
         ).unwrap();
 
         let mut transpiler = SentinelTranspiler::new();
-        transpiler.set_shared_paths(vec![shared_dir.to_path_buf()]);
-        let result = transpiler.transpile_file(test_file).unwrap();
+        transpiler.set_shared_paths(vec![shared_dir.clone()]);
+        let result = transpiler.transpile_file(&test_file).unwrap();
 
-        // The main type should be expanded
-        assert!(
-            result.contains("type funnel_result ="),
-            "Expected funnel_result type, got: {}", result
-        );
-
-        // The nested types should also be resolved and expanded
-        assert!(
-            result.contains("type stage_ref ="),
-            "Expected stage_ref to be recursively resolved, got: {}", result
-        );
-        assert!(
-            result.contains("type owner_ref ="),
-            "Expected owner_ref to be recursively resolved, got: {}", result
-        );
-
-        // Annotations should be stripped
-        assert!(
-            !result.contains("@desc"),
-            "Expected annotations to be stripped, got: {}", result
-        );
-        assert!(
-            !result.contains("@format"),
-            "Expected annotations to be stripped, got: {}", result
-        );
+        assert!(result.contains("type funnel_result ="), "Expected funnel_result type, got: {}", result);
+        assert!(result.contains("type stage_ref ="), "Expected stage_ref to be recursively resolved, got: {}", result);
+        assert!(result.contains("type owner_ref ="), "Expected owner_ref to be recursively resolved, got: {}", result);
+        assert!(!result.contains("@desc"), "Expected annotations to be stripped, got: {}", result);
+        assert!(!result.contains("@format"), "Expected annotations to be stripped, got: {}", result);
 
         // Dependencies should appear before the type that references them
         let stage_pos = result.find("type stage_ref =").unwrap();
         let owner_pos = result.find("type owner_ref =").unwrap();
         let funnel_pos = result.find("type funnel_result =").unwrap();
-        assert!(
-            stage_pos < funnel_pos,
-            "stage_ref should appear before funnel_result"
-        );
-        assert!(
-            owner_pos < funnel_pos,
-            "owner_ref should appear before funnel_result"
-        );
-
-        // Cleanup
-        let _ = fs::remove_dir_all(shared_dir);
-        let _ = fs::remove_file(test_file);
+        assert!(stage_pos < funnel_pos, "stage_ref should appear before funnel_result");
+        assert!(owner_pos < funnel_pos, "owner_ref should appear before funnel_result");
     }
 
     #[test]
     fn test_recursive_import_no_cycles() {
-        let shared_dir = Path::new("/tmp/test_shared_cycles");
-        let _ = fs::create_dir_all(shared_dir);
+        let tmp = TempDir::new().unwrap();
+        let shared_dir = tmp.path().join("shared");
+        fs::create_dir_all(&shared_dir).unwrap();
 
-        // Type A references type B
-        fs::write(
-            shared_dir.join("type_a.rbs"),
-            "type type_a = { ref: type_b }\n",
-        ).unwrap();
+        fs::write(shared_dir.join("type_a.rbs"), "type type_a = { ref: type_b }\n").unwrap();
+        fs::write(shared_dir.join("type_b.rbs"), "type type_b = { ref: type_a }\n").unwrap();
 
-        // Type B references type A (cycle)
+        let test_file = tmp.path().join("test.rb");
         fs::write(
-            shared_dir.join("type_b.rbs"),
-            "type type_b = { ref: type_a }\n",
-        ).unwrap();
-
-        let test_file = Path::new("/tmp/test_cycle_import.rb");
-        fs::write(
-            test_file,
+            &test_file,
             "class Foo\n  # @rbs import type_a\n\n  #: () -> type_a\n  def call\n  end\nend\n",
         ).unwrap();
 
         let mut transpiler = SentinelTranspiler::new();
-        transpiler.set_shared_paths(vec![shared_dir.to_path_buf()]);
-        let result = transpiler.transpile_file(test_file).unwrap();
+        transpiler.set_shared_paths(vec![shared_dir.clone()]);
+        let result = transpiler.transpile_file(&test_file).unwrap();
 
-        // Both types should be present (no infinite loop)
         assert!(result.contains("type type_a ="), "Expected type_a, got: {}", result);
         assert!(result.contains("type type_b ="), "Expected type_b, got: {}", result);
-
-        let _ = fs::remove_dir_all(shared_dir);
-        let _ = fs::remove_file(test_file);
     }
 
     #[test]
     fn test_recursive_import_types_in_same_file() {
-        // When sub-types are in the same file as the main type,
-        // they should already be included (existing behavior)
-        let shared_dir = Path::new("/tmp/test_shared_same_file");
-        let _ = fs::create_dir_all(shared_dir);
+        let tmp = TempDir::new().unwrap();
+        let shared_dir = tmp.path().join("shared");
+        fs::create_dir_all(&shared_dir).unwrap();
 
         fs::write(
             shared_dir.join("bundle.rbs"),
             "type inner = { id: String }\n\ntype bundle = { item: inner }\n",
         ).unwrap();
 
-        let test_file = Path::new("/tmp/test_same_file_import.rb");
+        let test_file = tmp.path().join("test.rb");
         fs::write(
-            test_file,
+            &test_file,
             "class Foo\n  # @rbs import bundle\n\n  #: () -> bundle\n  def call\n  end\nend\n",
         ).unwrap();
 
         let mut transpiler = SentinelTranspiler::new();
-        transpiler.set_shared_paths(vec![shared_dir.to_path_buf()]);
-        let result = transpiler.transpile_file(test_file).unwrap();
+        transpiler.set_shared_paths(vec![shared_dir.clone()]);
+        let result = transpiler.transpile_file(&test_file).unwrap();
 
         assert!(result.contains("type inner ="), "Expected inner, got: {}", result);
         assert!(result.contains("type bundle ="), "Expected bundle, got: {}", result);
-
-        let _ = fs::remove_dir_all(shared_dir);
-        let _ = fs::remove_file(test_file);
     }
 
     #[test]
     fn test_references_type_word_boundary() {
-        // "error" should not match "error_code"
         assert!(SentinelTranspiler::references_type("type foo = { e: error }", "error"));
         assert!(!SentinelTranspiler::references_type("type foo = { e: error_code }", "error"));
         assert!(SentinelTranspiler::references_type("type foo = { e: Array[error] }", "error"));
         assert!(SentinelTranspiler::references_type("type foo = { e: error, f: String }", "error"));
-        // references_type is a pure string check — the caller skips the defined name
         assert!(SentinelTranspiler::references_type("type error = { code: String }", "error"));
     }
 }


### PR DESCRIPTION
## Summary

When `# @rbs import foo` expands a type that references other types defined in `sig/shared/`, those nested types are now automatically resolved and inlined in the generated `.rbs` output.

**Before:** Only the directly imported type was expanded. Nested references were left as bare names, causing Steep `RBS::UnknownTypeName` errors.

```rbs
# sig/generated/services/tool/get_funnel.rbs
type funnel_tools_api_result = {
  title: String,
  ?stages: Array[stage_tools_ref],  # ← Steep error: unknown type
  ?owner: owner_ref,                # ← Steep error: unknown type
}
```

**After:** Nested types are recursively resolved and emitted before the type that references them.

```rbs
type stage_tools_ref = {id: String, title: String, type: String, url: String, ?workflow_url: String}
type owner_ref = {external_id: String, name: String, email: String}
type funnel_tools_api_result = {
  title: String,
  ?stages: Array[stage_tools_ref],  # ← resolves to the type above
  ?owner: owner_ref,                # ← resolves to the type above
}
```

## Changes

- `resolve_import` is now recursive with cycle detection (`HashSet`)
- `resolve_single_import` falls back to scanning all `.rbs` files when the type name doesn't match a filename (e.g. `stage_tools_ref` defined inside `funnel.rbs`)
- `index_shared_types` collects all available type names across `shared_paths`
- `references_type` checks for whole-word type name matches in alias bodies
- Dependencies are emitted before the types that reference them

## Test plan

- [x] 4 new unit tests: recursive resolution, cycle detection, same-file types, word boundary matching
- [x] All 56 tests pass
- [x] Verified against the Hire monolith: `stage_tools_ref`, `location_ref`, `owner_ref`, `position_ref`, `workflow_ref` are now expanded inline in funnel handler `.rbs` files
- [x] Steep reports 0 errors on the monolith with the new binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)