### PR TITLE
Add MIT license, benchmark table, and watching DX comparison

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Andrew Gauger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -161,6 +161,29 @@ require('lspconfig').steep.setup({
   -- ... rest of your config
 })---
 ```
+## Feature Comparison
+
+Sentinel covers the full rbs-inline annotation surface and is ahead on two items from the [rbs-inline roadmap](https://github.com/soutaro/rbs-inline/wiki/Roadmap):
+
+| Feature | rbs-inline | sentinel |
+|---------|-----------|---------|
+| Instance methods (`#:`) | ✓ | ✓ |
+| Self/class methods | ✓ | ✓ |
+| Modules | ✓ | ✓ |
+| `attr_reader` / `attr_writer` / `attr_accessor` | ✓ | ✓ |
+| Type alias declarations (`# @rbs type`) | not yet | ✓ |
+| Overload annotations | not yet | partial (last annotation wins) |
+| Shared type imports (`# @rbs import`) | — | ✓ transitive, cycle-safe |
+| Header required per file | yes | no |
+| Class variables | not yet | not yet |
+| Module functions | not yet | not yet |
+| Interface declarations | not yet | not yet |
+| Class/module aliases | not yet | not yet |
+
+The `# @rbs import <name>` feature is unique to Sentinel: it resolves shared type definitions from `sig/shared/`, walks transitive dependencies in topological order, and handles circular references. rbs-inline has no equivalent.
+
+---
+
 ## Performance
 
 Benchmarked on a production Rails app (5,000+ files):

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # 🛡️ Sentinel
 
-**Sentinel** is a high-performance Rust-powered watcher that keeps your Ruby code and RBS type signatures in perfect sync. It bridges the gap between dynamic Ruby models and static RBS type definitions.
+RBS type signature generator for Rails — Rust-powered, CI-ready.
+
+**Sentinel** keeps your Ruby code and RBS type signatures in perfect sync. It bridges the gap between dynamic Ruby models and static RBS type definitions using a Rust transpiler for speed at scale.
 
 ## 🚀 Getting Started
 
@@ -159,8 +161,45 @@ require('lspconfig').steep.setup({
   -- ... rest of your config
 })---
 ```
+## Performance
+
+Benchmarked on a production Rails app (5,000+ files):
+
+| Tool | Files generated | Time | Header required |
+|------|----------------|------|----------------|
+| inline-rbs | 174 | 2.540s | yes |
+| sentinel | 174 | 306ms | no |
+
+~8x faster on identical output. Sentinel also requires no opt-in header in each source file, which matters when rolling out type coverage across a large existing codebase or a Rails engine where you don't own every file.
+
+### Watching for changes
+
+**inline-rbs** has no built-in watcher. The recommended approach requires composing three external tools:
+
+```bash
+fswatch -0 lib | xargs -0 -n1 bundle exec rbs-inline --output
+```
+
+This requires `fswatch` to be installed separately, spawns a new Ruby process on every file save, and is macOS-specific.
+
+**Sentinel** builds and watches in one command:
+
+```bash
+bundle exec sentinel
+```
+
+The watcher is built into the Rust binary — no extra dependencies, cross-platform, and no per-save process spawn overhead.
+
+---
+
 ## ⚠️ Troubleshooting
 
 If Steep fails to start with "Exit Code 2", ensure you are running within the correct environment. Sentinel depends on the bundle context to resolve paths correctly. If using asdf or rbenv, ensure your shims are updated:
 
     asdf reshim ruby
+
+---
+
+## License
+
+MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

- Adds `LICENSE` file (MIT) — the gemspec declared MIT but no file existed; anyone visiting the repo after a conference talk couldn't legally fork or use it
- Updates README tagline to be search-friendly: _RBS type signature generator for Rails — Rust-powered, CI-ready_
- Adds benchmark table: 174 files in 306ms (sentinel) vs 174 files in 2.540s (inline-rbs) on a 5,000+ file production app, with the header requirement difference noted
- Adds side-by-side watching comparison: `bundle exec sentinel` vs the `fswatch | xargs | bundle exec rbs-inline` pipeline inline-rbs requires

## Test plan

- [ ] Verify LICENSE renders correctly on GitHub repo page
- [ ] Verify benchmark table renders in README preview
- [ ] Confirm numbers match your local benchmark run

🤖 Generated with [Claude Code](https://claude.com/claude-code)