### PR TITLE
Correct inline-rbs memory figure to 76.8 MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,10 +190,10 @@ Benchmarked on a production Rails app (5,000+ files):
 
 | Tool | Files generated | Time | Peak memory | Header required |
 |------|----------------|------|-------------|----------------|
-| inline-rbs | 174 | 2.540s | 63 MB | yes |
+| inline-rbs | 174 | 2.540s | 76.8 MB | yes |
 | sentinel | 174 | 306ms | 9.7 MB | no |
 
-~8x faster, ~6.5x less memory, identical output. Sentinel also requires no opt-in header in each source file, which matters when rolling out type coverage across a large existing codebase or a Rails engine where you don't own every file.
+~8x faster, ~8x less memory, identical output. Sentinel also requires no opt-in header in each source file, which matters when rolling out type coverage across a large existing codebase or a Rails engine where you don't own every file.
 
 ### Watching for changes
 


### PR DESCRIPTION
## Summary

Corrects the inline-rbs peak memory figure from 63 MB to 76.8 MB, measured on the actual production folder. Summary line updated to "~8x faster, ~8x less memory" — cleaner and accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)