### PR TITLE
Keep blocking work off the tokio runtime; transpile_file returns anyhow::Result

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,17 +18,27 @@ async fn main() -> Result<()> {
         "init" => {
             let config = SentinelConfig::ensure_exists()?;
             std::fs::create_dir_all(config.output_path())?;
+            let output = config.output_path();
             let shared = config.shared_type_paths();
             for folder in config.folder_paths() {
-                init::run(&folder, &config.output_path(), &shared);
+                // init::run fans out over files with rayon (a blocking call), so
+                // run it on the blocking pool rather than a tokio worker thread.
+                let (output, shared) = (output.clone(), shared.clone());
+                tokio::task::spawn_blocking(move || init::run(&folder, &output, &shared)).await?;
             }
         }
         "check" => {
             let config = SentinelConfig::load()?;
+            let output = config.output_path();
             let shared = config.shared_type_paths();
             let mut all_ok = true;
             for folder in config.folder_paths() {
-                if !check::run(&folder, &config.output_path(), &shared) {
+                // check::run is rayon-parallel and blocking; keep it off the runtime.
+                let (output, shared) = (output.clone(), shared.clone());
+                let ok =
+                    tokio::task::spawn_blocking(move || check::run(&folder, &output, &shared))
+                        .await?;
+                if !ok {
                     all_ok = false;
                 }
             }
@@ -39,9 +49,12 @@ async fn main() -> Result<()> {
         "watch" => {
             let config = SentinelConfig::ensure_exists()?;
             std::fs::create_dir_all(config.output_path())?;
+            let output = config.output_path();
             let shared = config.shared_type_paths();
             for folder in config.folder_paths() {
-                init::run(&folder, &config.output_path(), &shared);
+                // Same blocking rayon batch as `init`, before the async watch loop starts.
+                let (output, shared) = (output.clone(), shared.clone());
+                tokio::task::spawn_blocking(move || init::run(&folder, &output, &shared)).await?;
             }
             let watcher = SentinelWatcher::new(&config)?.with_plugins();
             watcher.run().await;

--- a/src/transpiler.rs
+++ b/src/transpiler.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use std::fs;
 use std::path::Path;
 use tree_sitter::{Node, Parser};
@@ -824,9 +825,12 @@ impl SentinelTranspiler {
     pub fn transpile_file(
         &mut self,
         rb_path: &Path,
-    ) -> Result<String, Box<dyn std::error::Error>> {
+    ) -> anyhow::Result<String> {
         let source = fs::read_to_string(rb_path)?;
-        let tree = self.parser.parse(&source, None).ok_or("Failed to parse")?;
+        let tree = self
+            .parser
+            .parse(&source, None)
+            .context("Failed to parse")?;
 
         let info = Self::collect_structure(&source, tree.root_node(), &self.shared_paths);
 

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,7 +1,7 @@
 use crate::config::SentinelConfig;
 use crate::plugin::{AngleBracketPlugin, SentinelPlugin, TypeCasePlugin, VoidArgumentPlugin};
 use crate::transpiler::SentinelTranspiler;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -102,9 +102,10 @@ impl SentinelWatcher {
                 }
             }
 
-            // Process all unique changed .rb files
+            // Process all unique changed .rb files. The transpiler is handed
+            // into handle_change and returned, so it is reused across changes.
             for path in &changed_paths {
-                self.handle_change(&mut transpiler, path).await;
+                transpiler = self.handle_change(transpiler, path).await;
             }
         }
     }
@@ -114,15 +115,43 @@ impl SentinelWatcher {
         self.app_roots.iter().find(|root| path.starts_with(root))
     }
 
-    async fn handle_change(&self, transpiler: &mut SentinelTranspiler, path: &Path) {
+    async fn handle_change(
+        &self,
+        mut transpiler: SentinelTranspiler,
+        path: &Path,
+    ) -> SentinelTranspiler {
         println!(
             "🔍 Change detected: {:?}",
             path.file_name().unwrap_or_default()
         );
 
-        match transpiler.transpile_file(path) {
+        // Pure path math: cheap, so leave it on the async thread.
+        let target_path = self.derive_sig_path(path);
+
+        // Owned copies to move across the blocking boundary.
+        let rb_path = path.to_path_buf();
+        let target = target_path.clone();
+
+        // Tree-sitter parsing, the .rb read, and the .rbs write are blocking and
+        // CPU-bound. Run them on the blocking pool, not a tokio worker thread.
+        // The transpiler moves in and comes back out so we keep reusing it.
+        let (transpiler, result) = tokio::task::spawn_blocking(move || {
+            let result = (|| -> anyhow::Result<String> {
+                let rbs = transpiler.transpile_file(&rb_path).context("transpiling")?;
+                if let Some(parent) = target.parent() {
+                    let _ = std::fs::create_dir_all(parent);
+                }
+                std::fs::write(&target, &rbs).context("writing RBS")?;
+                Ok(rbs)
+            })();
+            (transpiler, result)
+        })
+        .await
+        .expect("transpile task panicked");
+
+        match result {
             Ok(rbs_content) => {
-                // 1. RUN PLUGINS (The new linter system)
+                // Plugin lints are cheap string scans, so run them here.
                 for plugin in &self.plugins {
                     let issues = plugin.check(&rbs_content);
                     if !issues.is_empty() {
@@ -136,23 +165,12 @@ impl SentinelWatcher {
                         }
                     }
                 }
-
-                let target_path = self.derive_sig_path(path);
-
-                // 2. Ensure directory exists
-                if let Some(parent) = target_path.parent() {
-                    let _ = std::fs::create_dir_all(parent);
-                }
-
-                // 3. Write file
-                if let Err(e) = std::fs::write(&target_path, &rbs_content) {
-                    eprintln!("❌ Failed to write RBS: {}", e);
-                } else {
-                    println!("✅ RBS Synced -> {:?}", target_path);
-                }
+                println!("✅ RBS Synced -> {:?}", target_path);
             }
-            Err(e) => eprintln!("❌ Transpiler error: {}", e),
+            Err(e) => eprintln!("❌ {:#}", e),
         }
+
+        transpiler
     }
 
     fn derive_sig_path(&self, rb_path: &Path) -> PathBuf {


### PR DESCRIPTION
## What

Two related fixes so synchronous, CPU-bound work never runs on a tokio worker thread, plus an error-type cleanup that makes the second fix clean.

### 1. `init`/`check` rayon batches (commit 1)

`init::run` and `check::run` fan out over files with rayon's `par_iter().for_each(...)`, which blocks the calling thread until the whole batch completes. They were invoked directly inside `#[tokio::main]`. Each call is now wrapped in `tokio::task::spawn_blocking`.

### 2. The watch loop (commit 2)

`handle_change` did synchronous tree-sitter parsing, the `.rb` read, and the `.rbs` write directly inside the async watch loop, blocking a worker thread on every file change. The whole unit now runs in a single `spawn_blocking`. The transpiler is handed in and returned, so it is still reused across changes. Cheap work (path math, plugin string scans) stays on the async thread.

A single `spawn_blocking` around the unit beats `tokio::fs`: `tokio::fs` is itself `spawn_blocking` under the hood and would offload only the I/O, leaving the tree-sitter parse on the runtime thread.

### 3. `transpile_file` returns `anyhow::Result<String>`

Previously it returned `Box<dyn Error>`, which is **not `Send`** and so cannot cross a `spawn_blocking` boundary. `anyhow::Error` is `Send + Sync + 'static`, so the real error crosses with no stringifying, and `.context("transpiling")` / `.context("writing RBS")` preserve the distinct messages. `anyhow` was already a dependency. Callers in `init.rs` and `check.rs` only `Display` the error, so they are unchanged.

## Why

Harmless today, since nothing async runs concurrently with these phases. But it is a latent blocking-the-runtime footgun: overlap any of this with live tasks and it would stall the executor and starve every task sharing the thread.

## Behavior

Unchanged. Folders and changes are processed in the same order. The only observable difference is that in the watch loop, plugin lint warnings now print after the write instead of before, which is harmless (linting never gated the write).

## Testing

- `cargo build` clean
- `cargo test` — 57 passed, 0 failed
- `cargo clippy` — no new warnings (the 12 reported are all pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)